### PR TITLE
added function to make sure there are not duplicate answer options

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -20,7 +20,11 @@ const shows = ['The Last Blockbuster',
     'Bloodline',
     'Dead to Me',
     'Godless',
-    'Jericho'
+    'Jericho',
+    'Bridgerton',
+    'Orange is the New Black',
+    'The Witcher',
+    'Tiger Kind'
 
 ];
 
@@ -80,7 +84,12 @@ Actor.prototype.getAnswer = function () {
     shuffle(actors);
 
     for (let i = 0; i < 3; i++) {
+        if (this.name !== actors[i]){
         temp.push(actors[i]);
+        }
+        else {
+            temp.push[i+1]
+        }
     }
 
     temp.push(this.name);


### PR DESCRIPTION
This works with the exception of Bridgerton because we have two shows with this name. We can either change that picture to a different show or remove it from the 'incorrect' shows array. Either will work but just removing it from the array is probably best. 